### PR TITLE
Add Russian roulette termination to triangle shader

### DIFF
--- a/src/shaders/shader_tris.wgsl
+++ b/src/shaders/shader_tris.wgsl
@@ -323,6 +323,16 @@ fn trace(ray: Ray, state: ptr<function, u32>) -> vec3f {
     }
     current_ray = scatter(state, current_ray, hit);
     attenuation *= hit.material.albedo.rgb * 0.7;
+
+    if (b > 2) {
+      let luminance = dot(attenuation, vec3f(0.2126, 0.7152, 0.0722));
+      let survival_probability = clamp(luminance, 0.05, 1.0);
+      let random_sample = rng_float(state);
+      if (random_sample > survival_probability) {
+        break;
+      }
+      attenuation /= survival_probability;
+    }
   }
 
   let sky = mix(SKY, BLUE, ray.direction.y*0.5 + 0.5);


### PR DESCRIPTION
## Summary
- extend the triangle shader trace loop with a luminance-based Russian roulette step once several bounces have occurred
- terminate paths based on a random sample and rescale attenuation to keep the estimator unbiased

## Testing
- `cargo run --release --bin raytracer` *(fails: no bin target named `raytracer`; available bin is `wgsl_toy`)*
- `cargo run --release --bin wgsl_toy` *(fails at runtime: winit cannot open a display in this headless environment)*
- `cargo test` *(fails: renderer tests require a GPU/display backend not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10f0ba8e48330ae532ca7ae5c5fb6